### PR TITLE
Adaptions to make edit config work

### DIFF
--- a/lib/atom-sync.coffee
+++ b/lib/atom-sync.coffee
@@ -16,7 +16,7 @@ module.exports = AtomSync =
     # @subscriptions.add atom.commands.add 'atom-workspace', 'atom-sync:debug': (e) =>
     #   @controller.debug @getProjectPath atom.workspace.getActivePaneItem().buffer.file.path
 
-    @subscriptions.add atom.commands.add '.tree-view.full-menu .header.list-item', 'atom-sync:configure': (e) =>
+    @subscriptions.add atom.commands.add '.tree-view .header.list-item', 'atom-sync:configure': (e) =>
       @controller.onCreate @getSelectedPath e.target
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'atom-sync:upload-project': (e) =>


### PR DESCRIPTION
change style to `.tree-view .header.list-item` to make opening the config work again. It has not worked on my mac until I changed this line.